### PR TITLE
Test cases baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,4 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
-FJS.Host/Generated
+*/Generated

--- a/FJS.Common/Metadata/RootTypeAttribute.cs
+++ b/FJS.Common/Metadata/RootTypeAttribute.cs
@@ -1,6 +1,6 @@
 namespace FJS.Common.Metadata
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class RootTypeAttribute : Attribute
     {
         public RootTypeAttribute(Type type)

--- a/FJS.UnitTests/Collections/Array/ComplexProperties.cs
+++ b/FJS.UnitTests/Collections/Array/ComplexProperties.cs
@@ -1,0 +1,50 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Collections.Array;
+
+public class ComplexPropertiesTests
+{
+    [Fact]
+    public void SerializeComplexValuesTest()
+    {
+        TestData3 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost5 host = new();
+            host.WriteTestData(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeDictionaryValuesTest()
+    {
+        TestData3WithDictionaryValues data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost5 host = new();
+            host.WriteTestData3WithDictionaryValues(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestData3))]
+[RootType(typeof(TestData3WithDictionaryValues))]
+partial class SerializerHost5
+{
+}
+
+class TestData3
+{
+    public TestData2[]? Data { get; set; }
+}
+
+class TestData3WithDictionaryValues
+{
+    public Dictionary<string, TestData2>[]? Data { get; set; }
+}

--- a/FJS.UnitTests/Collections/Array/SimpleProperties.cs
+++ b/FJS.UnitTests/Collections/Array/SimpleProperties.cs
@@ -1,0 +1,63 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Collections.Array;
+
+public class SimplePropertiesTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        TestData2 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost2 host = new();
+            host.WriteTestData2(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestData2))]
+partial class SerializerHost2
+{
+}
+
+class TestData2
+{
+    public byte[]? ByteProp { get; set; }
+
+    public sbyte[]? SByteProp { get; set; }
+
+    public short[]? ShortProp { get; set; }
+
+    public ushort[]? UShortProp { get; set; }
+
+    public int[]? IntProp { get; set; }
+
+    public uint[]? UIntProp { get; set; }
+
+    public long[]? LongProp { get; set; }
+
+    public ulong[]? ULongProp { get; set; }
+
+    public float[]? FloatProp { get; set; }
+
+    public double[]? DoubleProp { get; set; }
+
+    public string[]? StringProp { get; set; }
+
+    public Version[]? VersionProp { get; set; }
+
+    public Guid[]? GuidProp { get; set; }
+
+    public TimeSpan[]? TimeSpanProp { get; set; }
+
+    public DateTime[]? DateTimeProp { get; set; }
+
+    public char[]? CharProp { get; set; }
+
+    public Rune[]? RuneProp { get; set; }
+}

--- a/FJS.UnitTests/Collections/Dictionary/ComplexProperties.cs
+++ b/FJS.UnitTests/Collections/Dictionary/ComplexProperties.cs
@@ -1,0 +1,88 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Collections.Dictionary;
+
+public class ComplexPropertiesTests
+{
+    [Fact]
+    public void SerializeDictionaryWithStringKeys()
+    {
+        TestData3WithStringKeys data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost8 host = new();
+            host.WriteTestData3WithStringKeys(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeDictionaryWithIntegralKeys()
+    {
+        TestData3WithIntegralKeys data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost8 host = new();
+            host.WriteTestData3WithIntegralKeys(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeDictionaryWithArrayValues()
+    {
+        TestData3WithArrayValues data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost8 host = new();
+            host.WriteTestData3WithArrayValues(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeDictionaryWithDictionaryValues()
+    {
+        TestData3WithDictionaryValues data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost8 host = new();
+            host.WriteTestData3WithDictionaryValues(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestData3WithStringKeys))]
+[RootType(typeof(TestData3WithIntegralKeys))]
+[RootType(typeof(TestData3WithArrayValues))]
+[RootType(typeof(TestData3WithDictionaryValues))]
+partial class SerializerHost8
+{
+}
+
+class TestData3WithStringKeys
+{
+    public Dictionary<string, TestData2WithStringKeys>? Data { get; set; }
+}
+
+class TestData3WithIntegralKeys
+{
+    public Dictionary<int, TestData2WithStringKeys>? Data { get; set; }
+}
+
+class TestData3WithArrayValues
+{
+    public Dictionary<string, List<TestData2WithStringKeys>>? Data { get; set; }
+}
+
+class TestData3WithDictionaryValues
+{
+    public Dictionary<string, Dictionary<string, TestData2WithStringKeys>>? Data { get; set; }
+}

--- a/FJS.UnitTests/Collections/Dictionary/SimpleProperties.cs
+++ b/FJS.UnitTests/Collections/Dictionary/SimpleProperties.cs
@@ -1,0 +1,114 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Collections.Dictionary;
+
+public class SimplePropertiesTests
+{
+    [Fact]
+    public void SerializeDictionaryWithStringKeys()
+    {
+        TestData2WithStringKeys data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost9 host = new();
+            host.WriteTestData2WithStringKeys(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeDictionaryWithIntegralKeys()
+    {
+        TestData2WithIntegralKeys data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost9 host = new();
+            host.WriteTestData2WithIntegralKeys(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestData2WithStringKeys))]
+[RootType(typeof(TestData2WithIntegralKeys))]
+partial class SerializerHost9
+{
+}
+
+class TestData2WithStringKeys
+{
+    public Dictionary<string, byte>? ByteProp { get; set; }
+
+    public Dictionary<string, sbyte>? SByteProp { get; set; }
+
+    public Dictionary<string, short>? ShortProp { get; set; }
+
+    public Dictionary<string, ushort>? UShortProp { get; set; }
+
+    public Dictionary<string, int>? IntProp { get; set; }
+
+    public Dictionary<string, uint>? UIntProp { get; set; }
+
+    public Dictionary<string, long>? LongProp { get; set; }
+
+    public Dictionary<string, ulong>? ULongProp { get; set; }
+
+    public Dictionary<string, float>? FloatProp { get; set; }
+
+    public Dictionary<string, double>? DoubleProp { get; set; }
+
+    public Dictionary<string, string>? StringProp { get; set; }
+
+    public Dictionary<string, Version>? VersionProp { get; set; }
+
+    public Dictionary<string, Guid>? GuidProp { get; set; }
+
+    public Dictionary<string, TimeSpan>? TimeSpanProp { get; set; }
+
+    public Dictionary<string, DateTime>? DateTimeProp { get; set; }
+
+    public Dictionary<string, char>? CharProp { get; set; }
+
+    public Dictionary<string, Rune>? RuneProp { get; set; }
+}
+
+class TestData2WithIntegralKeys
+{
+    public Dictionary<int, byte>? ByteProp { get; set; }
+
+    public Dictionary<int, sbyte>? SByteProp { get; set; }
+
+    public Dictionary<int, short>? ShortProp { get; set; }
+
+    public Dictionary<int, ushort>? UShortProp { get; set; }
+
+    public Dictionary<int, int>? IntProp { get; set; }
+
+    public Dictionary<int, uint>? UIntProp { get; set; }
+
+    public Dictionary<int, long>? LongProp { get; set; }
+
+    public Dictionary<int, ulong>? ULongProp { get; set; }
+
+    public Dictionary<int, float>? FloatProp { get; set; }
+
+    public Dictionary<int, double>? DoubleProp { get; set; }
+
+    public Dictionary<int, string>? StringProp { get; set; }
+
+    public Dictionary<int, Version>? VersionProp { get; set; }
+
+    public Dictionary<int, Guid>? GuidProp { get; set; }
+
+    public Dictionary<int, TimeSpan>? TimeSpanProp { get; set; }
+
+    public Dictionary<int, DateTime>? DateTimeProp { get; set; }
+
+    public Dictionary<int, char>? CharProp { get; set; }
+
+    public Dictionary<int, Rune>? RuneProp { get; set; }
+}

--- a/FJS.UnitTests/Collections/List/ComplexProperties.cs
+++ b/FJS.UnitTests/Collections/List/ComplexProperties.cs
@@ -1,0 +1,31 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Collections.List;
+
+public class ComplexPropertiesTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        TestData3 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost7 host = new();
+            host.WriteTestData2(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestData3))]
+partial class SerializerHost7
+{
+}
+
+class TestData3
+{
+    public List<TestData2>? Data { get; set; }
+}

--- a/FJS.UnitTests/Collections/List/SimpleProperties.cs
+++ b/FJS.UnitTests/Collections/List/SimpleProperties.cs
@@ -1,0 +1,63 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Collections.List;
+
+public class SimplePropertiesTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        TestData2 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost6 host = new();
+            host.WriteTestData2(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestData2))]
+partial class SerializerHost6
+{
+}
+
+class TestData2
+{
+    public List<byte>? ByteProp { get; set; }
+
+    public List<sbyte>? SByteProp { get; set; }
+
+    public List<short>? ShortProp { get; set; }
+
+    public List<ushort>? UShortProp { get; set; }
+
+    public List<int>? IntProp { get; set; }
+
+    public List<uint>? UIntProp { get; set; }
+
+    public List<long>? LongProp { get; set; }
+
+    public List<ulong>? ULongProp { get; set; }
+
+    public List<float>? FloatProp { get; set; }
+
+    public List<double>? DoubleProp { get; set; }
+
+    public List<string>? StringProp { get; set; }
+
+    public List<Version>? VersionProp { get; set; }
+
+    public List<Guid>? GuidProp { get; set; }
+
+    public List<TimeSpan>? TimeSpanProp { get; set; }
+
+    public List<DateTime>? DateTimeProp { get; set; }
+
+    public List<char>? CharProp { get; set; }
+
+    public List<Rune>? RuneProp { get; set; }
+}

--- a/FJS.UnitTests/Customizations/JsonIgnore/Properties.cs
+++ b/FJS.UnitTests/Customizations/JsonIgnore/Properties.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+using FJS.Common.Metadata;
+
+namespace FJS.UnitTests.Customizations.JsonIgnore;
+
+public class IgnoredPropertiesTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        TestData6 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost3 host = new();
+            host.WriteTestData6(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestData6))]
+partial class SerializerHost3
+{
+}
+
+class TestData6
+{
+    public int AvailableProp { get; set; }
+
+    [JsonIgnore]
+    public int IgnoredProp { get; set; }
+
+    [JsonIgnore]
+    public int AlwaysIgnoredProp { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int IgnoredWhenDefault { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IgnoredWhenNul { get; set; }
+}

--- a/FJS.UnitTests/Customizations/JsonPropertyName/CustomNames.cs
+++ b/FJS.UnitTests/Customizations/JsonPropertyName/CustomNames.cs
@@ -1,0 +1,80 @@
+using FJS.Common.Metadata;
+using FJS.UnitTests.Utils;
+using System.Text.Json.Serialization;
+
+namespace FJS.Customizations.JsonPropertyName;
+
+public class CustomNameTests
+{
+    [Fact]
+    public void NoCollisionTest()
+    {
+        NoCollision data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost4 host = new();
+            host.WriteNoCollision(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void CollisionWithDefaultNameTest()
+    {
+        CollisionWithDefaultName data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost4 host = new();
+            host.WriteCollisionWithDefaultName(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void CollisionThroughAttributeTest()
+    {
+        CollisionThroughAttribute data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost4 host = new();
+            host.WriteCollisionThroughAttribute(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(NoCollision))]
+[RootType(typeof(CollisionWithDefaultName))]
+[RootType(typeof(CollisionThroughAttribute))]
+partial class SerializerHost4
+{
+}
+
+class NoCollision
+{
+    public int Prop1 { get; set; }
+
+    [JsonPropertyName("abc")]
+    public int Prop2 { get; set; }
+}
+
+class CollisionWithDefaultName
+{
+    public int Prop1 { get; set; }
+
+    [JsonPropertyName("Prop1")]
+    public int Prop2 { get; set; }
+}
+
+class CollisionThroughAttribute
+{
+    [JsonPropertyName("abc")]
+    public int Prop1 { get; set; }
+
+    [JsonPropertyName("abc")]
+    public int Prop2 { get; set; }
+}

--- a/FJS.UnitTests/FJS.UnitTests.csproj
+++ b/FJS.UnitTests/FJS.UnitTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FJS.Common.Metadata" />
+    <Using Include="FJS.UnitTests.Utils" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FJS.Generator\FJS.Generator.csproj" OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\FJS.Common\FJS.Common.csproj" />
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+  </ItemGroup>
+</Project>

--- a/FJS.UnitTests/Primitives/NullableFields.cs
+++ b/FJS.UnitTests/Primitives/NullableFields.cs
@@ -1,0 +1,59 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Primitives;
+
+public class NullableFieldsTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        NullableFieldsHost data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            NullableFieldsHost host = new();
+            host.WriteNullableFields(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(NullableFields))]
+partial class NullableFieldsHost
+{
+}
+
+class NullableFields
+{
+    public byte? ByteProp;
+
+    public sbyte? SByteProp;
+
+    public short? ShortProp;
+
+    public ushort? UShortProp;
+
+    public int? IntProp;
+
+    public uint? UIntProp;
+
+    public long? LongProp;
+
+    public ulong? ULongProp;
+
+    public float? FloatProp;
+
+    public double? DoubleProp;
+
+    public Guid? GuidProp;
+
+    public TimeSpan? TimeSpanProp;
+
+    public DateTime? DateTimeProp;
+
+    public char? CharProp;
+
+    public Rune? RuneProp;
+}

--- a/FJS.UnitTests/Primitives/NullableProperties.cs
+++ b/FJS.UnitTests/Primitives/NullableProperties.cs
@@ -1,0 +1,59 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Primitives;
+
+public class NullablePropertiesTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        NullableProperties data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            NullablePropertiesHost host = new();
+            host.WriteNullableProperties(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(NullableProperties))]
+partial class NullablePropertiesHost
+{
+}
+
+class NullableProperties
+{
+    public byte? ByteProp { get; set; }
+
+    public sbyte? SByteProp { get; set; }
+
+    public short? ShortProp { get; set; }
+
+    public ushort? UShortProp { get; set; }
+
+    public int? IntProp { get; set; }
+
+    public uint? UIntProp { get; set; }
+
+    public long? LongProp { get; set; }
+
+    public ulong? ULongProp { get; set; }
+
+    public float? FloatProp { get; set; }
+
+    public double? DoubleProp { get; set; }
+
+    public Guid? GuidProp { get; set; }
+
+    public TimeSpan? TimeSpanProp { get; set; }
+
+    public DateTime? DateTimeProp { get; set; }
+
+    public char? CharProp { get; set; }
+
+    public Rune? RuneProp { get; set; }
+}

--- a/FJS.UnitTests/Primitives/ScalarFields.cs
+++ b/FJS.UnitTests/Primitives/ScalarFields.cs
@@ -1,0 +1,63 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Primitives;
+
+public class ScalarFieldsTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        TestDataWithFields data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            ScalarFieldsHost host = new();
+            host.WriteTestDataWithFields(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestDataWithFields))]
+partial class ScalarFieldsHost
+{
+}
+
+class TestDataWithFields
+{
+    public byte ByteProp;
+
+    public sbyte SByteProp;
+
+    public short ShortProp;
+
+    public ushort UShortProp;
+
+    public int IntProp;
+
+    public uint UIntProp;
+
+    public long LongProp;
+
+    public ulong ULongProp;
+
+    public float FloatProp;
+
+    public double DoubleProp;
+
+    public string? StringProp;
+
+    public Version? VersionProp;
+
+    public Guid GuidProp;
+
+    public TimeSpan TimeSpanProp;
+
+    public DateTime DateTimeProp;
+
+    public char CharProp;
+
+    public Rune RuneProp;
+}

--- a/FJS.UnitTests/Primitives/ScalarProperties.cs
+++ b/FJS.UnitTests/Primitives/ScalarProperties.cs
@@ -1,0 +1,63 @@
+using FJS.Common.Metadata;
+using System.Text;
+
+namespace FJS.UnitTests.Primitives;
+
+public class ScalarPropertiesTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        TestDataWithProperties data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            ScalarPropertiesHost host = new();
+            host.WriteTestDataWithProperties(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(TestDataWithProperties))]
+partial class ScalarPropertiesHost
+{
+}
+
+class TestDataWithProperties
+{
+    public byte ByteProp { get; set; }
+
+    public sbyte SByteProp { get; set; }
+
+    public short ShortProp { get; set; }
+
+    public ushort UShortProp { get; set; }
+
+    public int IntProp { get; set; }
+
+    public uint UIntProp { get; set; }
+
+    public long LongProp { get; set; }
+
+    public ulong ULongProp { get; set; }
+
+    public float FloatProp { get; set; }
+
+    public double DoubleProp { get; set; }
+
+    public string? StringProp { get; set; }
+
+    public Version? VersionProp { get; set; }
+
+    public Guid GuidProp { get; set; }
+
+    public TimeSpan TimeSpanProp { get; set; }
+
+    public DateTime DateTimeProp { get; set; }
+
+    public char CharProp { get; set; }
+
+    public Rune RuneProp { get; set; }
+}

--- a/FJS.UnitTests/TypeSystem/Namespace/Host_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Namespace/Host_Variations.cs
@@ -1,0 +1,51 @@
+namespace FJS.UnitTests.TypeSystem.Namespace
+{
+    public class HostVariationTests
+    {
+        [Fact]
+        public void SerializeUsingGlobalHost()
+        {
+            TestData data = new();
+            var output1 = SerializerHelper.SerializeType(writer =>
+            {
+                GlobalHost1 host = new();
+                host.WriteTestData(writer, data);
+            });
+            var output2 = SerializerHelper.SerializeUsingSTJ(data);
+            Assert.Equal(output1, output2);
+        }
+
+        [Fact]
+        public void SerializeUsingNestedHost()
+        {
+            TestData data = new();
+            var output1 = SerializerHelper.SerializeType(writer =>
+            {
+                NestedHost1 host = new();
+                host.WriteTestData(writer, data);
+            });
+            var output2 = SerializerHelper.SerializeUsingSTJ(data);
+            Assert.Equal(output1, output2);
+        }
+    }
+
+    [GeneratedSerialier]
+    [RootType(typeof(TestData))]
+    partial class GlobalHost1
+    {
+    }
+
+    namespace Nested
+    {
+        [GeneratedSerialier]
+        [RootType(typeof(TestData))]
+        partial class NestedHost1
+        {
+        }
+    }
+
+    class TestData
+    {
+        public int Prop1 { get; set; }
+    }
+}

--- a/FJS.UnitTests/TypeSystem/Namespace/Type_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Namespace/Type_Variations.cs
@@ -1,0 +1,51 @@
+namespace FJS.UnitTests.TypeSystem.Namespace
+{
+    public class TypeVariationTests
+    {
+        [Fact]
+        public void SerializeTestDataTest()
+        {
+            TestData1 data = new();
+            var output1 = SerializerHelper.SerializeType(writer =>
+            {
+                GlobalHost2 host = new();
+                host.WriteTestData1(writer, data);
+            });
+            var output2 = SerializerHelper.SerializeUsingSTJ(data);
+            Assert.Equal(output1, output2);
+        }
+
+        [Fact]
+        public void SerializeNestedTestData2Test()
+        {
+            Nested.TestData2 data = new();
+            var output1 = SerializerHelper.SerializeType(writer =>
+            {
+                GlobalHost2 host = new();
+                host.WriteTestData2(writer, data);
+            });
+            var output2 = SerializerHelper.SerializeUsingSTJ(data);
+            Assert.Equal(output1, output2);
+        }
+    }
+
+    [GeneratedSerialier]
+    [RootType(typeof(TestData1))]
+    [RootType(typeof(Nested.TestData2))]
+    partial class GlobalHost2
+    {
+    }
+
+    namespace Nested
+    {
+        class TestData2
+        {
+            public int Prop1 { get; set; }
+        }
+    }
+
+    class TestData1
+    {
+        public int Prop1 { get; set; }
+    }
+}

--- a/FJS.UnitTests/TypeSystem/Nesting/Host_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Nesting/Host_Variations.cs
@@ -1,0 +1,31 @@
+namespace FJS.UnitTests.TypeSystem.Nesting;
+
+public class HostVariationTests
+{
+        [Fact]
+        public void Serialize()
+        {
+            TestData data = new();
+            var output1 = SerializerHelper.SerializeType(writer =>
+            {
+                HostParent.NestedHost2 host = new();
+                host.WriteTestData(writer, data);
+            });
+            var output2 = SerializerHelper.SerializeUsingSTJ(data);
+            Assert.Equal(output1, output2);
+        }
+}
+
+public partial class HostParent
+{
+    [GeneratedSerialier]
+    [RootType(typeof(TestData))]
+    public partial class NestedHost2
+    {
+    }
+}
+
+class TestData
+{
+    public int Prop1 { get; set; }
+}

--- a/FJS.UnitTests/TypeSystem/Nesting/Type_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Nesting/Type_Variations.cs
@@ -1,0 +1,31 @@
+namespace FJS.UnitTests.TypeSystem.Nesting;
+
+public class TypeVariationTests
+{
+    [Fact]
+    public void SerializeNestedTestData2Test()
+    {
+        Parent.TestData data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            NestedHost3 host = new();
+            host.WriteTestData(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(Parent.TestData))]
+partial class NestedHost3
+{
+}
+
+public class Parent
+{
+    public class TestData
+    {
+        public int Prop1 { get; set; }
+    }
+}

--- a/FJS.UnitTests/TypeSystem/ObjectGraphs/ObjectGraphs.cs
+++ b/FJS.UnitTests/TypeSystem/ObjectGraphs/ObjectGraphs.cs
@@ -1,0 +1,92 @@
+namespace FJS.UnitTests.TypeSystems.ObjectGraphs;
+
+public class ObjectGraphTests
+{
+    [Fact]
+    public void SerializeSelfReferenceTest()
+    {
+        SelfReference data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost1 host = new();
+            host.WriteSelfReference(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeCycle1Test()
+    {
+        Cycle1 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost1 host = new();
+            host.WriteCycle1(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeCycle2SameHostTest()
+    {
+        Cycle2 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost2 host = new();
+            host.WriteCycle2(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+
+    [Fact]
+    public void SerializeCycle2DifferentHostTest()
+    {
+        Cycle2 data = new();
+        var output1 = SerializerHelper.SerializeType(writer =>
+        {
+            SerializerHost1 host = new();
+            host.WriteCycle2(writer, data);
+        });
+        var output2 = SerializerHelper.SerializeUsingSTJ(data);
+        Assert.Equal(output1, output2);
+    }
+}
+
+class SelfReference
+{
+    public SelfReference? Parent { get; set; }
+    public List<SelfReference>? Children { get; set; }
+}
+
+class Cycle1
+{
+    public Cycle2? Other { get; set; }
+}
+
+class Cycle2
+{
+    public Cycle1? Other { get; set; }
+}
+
+[GeneratedSerialier]
+[RootType(typeof(SelfReference))]
+[RootType(typeof(Cycle1))]
+partial class SerializerHost1
+{
+}
+
+[GeneratedSerialier]
+[RootType(typeof(Cycle2))]
+partial class SerializerHost2
+{
+}
+
+[GeneratedSerialier]
+[RootType(typeof(Cycle2))]
+[RootType(typeof(Cycle2))]
+partial class SameRootMultipleTimesHost
+{
+}

--- a/FJS.UnitTests/Utils/SerializerHelper.cs
+++ b/FJS.UnitTests/Utils/SerializerHelper.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace FJS.UnitTests.Utils;
+
+static class SerializerHelper
+{
+    public static string SerializeType(Action<Utf8JsonWriter> writeAction)
+    {
+        MemoryStream ms = new();
+        Utf8JsonWriter writer = new(ms);
+
+        writeAction(writer);
+        writer.Flush();
+        ms.Position = 0;
+
+        StreamReader sr = new(ms);
+        var output = sr.ReadToEnd();
+        return output;
+    }
+
+    public static string SerializeUsingSTJ<T>(T obj)
+    {
+        MemoryStream ms = new();
+        Utf8JsonWriter writer = new(ms);
+        JsonSerializer.Serialize(obj);
+        writer.Flush();
+        ms.Position = 0;
+
+        StreamReader sr = new(ms);
+        var output = sr.ReadToEnd();
+        return output;
+    }
+}

--- a/FJS.sln
+++ b/FJS.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FJS.Generator", "FJS.Genera
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FJS.Common", "FJS.Common\FJS.Common.csproj", "{DB79BBAA-98F6-4DDA-BB7A-9C40EEF7C88C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FJS.UnitTests", "FJS.UnitTests\FJS.UnitTests.csproj", "{8D8E5CF5-A902-4641-8201-0830844D7988}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{DB79BBAA-98F6-4DDA-BB7A-9C40EEF7C88C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB79BBAA-98F6-4DDA-BB7A-9C40EEF7C88C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB79BBAA-98F6-4DDA-BB7A-9C40EEF7C88C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D8E5CF5-A902-4641-8201-0830844D7988}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D8E5CF5-A902-4641-8201-0830844D7988}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D8E5CF5-A902-4641-8201-0830844D7988}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D8E5CF5-A902-4641-8201-0830844D7988}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is a fast serializer for generating Json representation of objects, based o
     - [ ] camel case
     - [ ] pascal case
 - [ ] Polymorphic serialization
-- [ ] Ignore property or type
+- [ ] Ignored properties
 - [ ] Field serialization
 - [ ] Cyclic references
     - [ ] Type cycles
@@ -37,6 +37,8 @@ This is a fast serializer for generating Json representation of objects, based o
     - [ ] Primitive objects as element
     - [ ] Complex objects as element
     - [ ] Complex objects as value
+    - [ ] Arrays as value
+    - [ ] Dictionaries as value
     - [ ] [Readonly]Span<T>
 - [ ] Complex properties
 - [ ] Primitive types


### PR DESCRIPTION
Added test cases for following situations.

1. Type with arrays of simple properties.
2. Type with arrays of complex objects.
3. Type with array of dictionaries property.
4. Type with dictionary of simple properties.
5. Type with dictionary of complex objects.
6. Type with dictionary of arrays.
7. Type with dictionary of dictionaries.
8. Type with dictionary of string keys.
9. Type with dictionary of integral keys.
10. Types with custom property names.
11. Types with ignored properties.
12. Types with conditionally ignored properties.
13. Types with scalar properties.
14. Types with scalar fields.
15. Types with nullable scalar properties.
16. Types with nullable scalar fields.
17. Types with serializer in same namespace.
18. Types with serializer in different namespace.
19. Types directly in namespace.
20. Types nested in other types.
21. Types with self references in type system.
22. Types with loops in type system.

Fixed 3 critical bugs in the source generator.

1. Allowed each serialization host to support multiple types at the same time.
2. Stopped type system infinite recursion when discovering properties during model generation.
3. Bypassed a 'sequence contains no elements' bug for the time being in model builder.


Minor updates to readme.