### PR TITLE
Write method improvements

### DIFF
--- a/FJS.Generator/CodeGenerator.cs
+++ b/FJS.Generator/CodeGenerator.cs
@@ -43,7 +43,7 @@ namespace FJS.Generator
         static MethodDeclarationSyntax GenerateMethodForType(TypeData t, State state)
         {
             state.Processed.Add(t.Name);
-            return MethodDeclaration(ParseTypeName("void"), $"Write{t.Name}")
+            return MethodDeclaration(ParseTypeName("void"), $"Write")
                                  .AddModifiers(Token(PublicKeyword))
                                  .AddParameterListParameters(
                                      [

--- a/FJS.UnitTests/Collections/Array/ComplexProperties.cs
+++ b/FJS.UnitTests/Collections/Array/ComplexProperties.cs
@@ -12,7 +12,7 @@ public class ComplexPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost5 host = new();
-            host.WriteTestData(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -25,7 +25,7 @@ public class ComplexPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost5 host = new();
-            host.WriteTestData3WithDictionaryValues(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Collections/Array/SimpleProperties.cs
+++ b/FJS.UnitTests/Collections/Array/SimpleProperties.cs
@@ -12,7 +12,7 @@ public class SimplePropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost2 host = new();
-            host.WriteTestData2(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Collections/Dictionary/ComplexProperties.cs
+++ b/FJS.UnitTests/Collections/Dictionary/ComplexProperties.cs
@@ -12,7 +12,7 @@ public class ComplexPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost8 host = new();
-            host.WriteTestData3WithStringKeys(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -25,7 +25,7 @@ public class ComplexPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost8 host = new();
-            host.WriteTestData3WithIntegralKeys(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -38,7 +38,7 @@ public class ComplexPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost8 host = new();
-            host.WriteTestData3WithArrayValues(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -51,7 +51,7 @@ public class ComplexPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost8 host = new();
-            host.WriteTestData3WithDictionaryValues(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Collections/Dictionary/SimpleProperties.cs
+++ b/FJS.UnitTests/Collections/Dictionary/SimpleProperties.cs
@@ -12,7 +12,7 @@ public class SimplePropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost9 host = new();
-            host.WriteTestData2WithStringKeys(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -25,7 +25,7 @@ public class SimplePropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost9 host = new();
-            host.WriteTestData2WithIntegralKeys(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Collections/List/ComplexProperties.cs
+++ b/FJS.UnitTests/Collections/List/ComplexProperties.cs
@@ -12,7 +12,7 @@ public class ComplexPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost7 host = new();
-            host.WriteTestData2(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Collections/List/SimpleProperties.cs
+++ b/FJS.UnitTests/Collections/List/SimpleProperties.cs
@@ -12,7 +12,7 @@ public class SimplePropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost6 host = new();
-            host.WriteTestData2(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Customizations/JsonIgnore/Properties.cs
+++ b/FJS.UnitTests/Customizations/JsonIgnore/Properties.cs
@@ -12,7 +12,7 @@ public class IgnoredPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost3 host = new();
-            host.WriteTestData6(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Customizations/JsonPropertyName/CustomNames.cs
+++ b/FJS.UnitTests/Customizations/JsonPropertyName/CustomNames.cs
@@ -13,7 +13,7 @@ public class CustomNameTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost4 host = new();
-            host.WriteNoCollision(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -26,7 +26,7 @@ public class CustomNameTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost4 host = new();
-            host.WriteCollisionWithDefaultName(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -39,7 +39,7 @@ public class CustomNameTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost4 host = new();
-            host.WriteCollisionThroughAttribute(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Primitives/NullableFields.cs
+++ b/FJS.UnitTests/Primitives/NullableFields.cs
@@ -12,7 +12,7 @@ public class NullableFieldsTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             NullableFieldsHost host = new();
-            host.WriteNullableFields(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Primitives/NullableProperties.cs
+++ b/FJS.UnitTests/Primitives/NullableProperties.cs
@@ -12,7 +12,7 @@ public class NullablePropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             NullablePropertiesHost host = new();
-            host.WriteNullableProperties(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Primitives/ScalarFields.cs
+++ b/FJS.UnitTests/Primitives/ScalarFields.cs
@@ -12,7 +12,7 @@ public class ScalarFieldsTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             ScalarFieldsHost host = new();
-            host.WriteTestDataWithFields(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/Primitives/ScalarProperties.cs
+++ b/FJS.UnitTests/Primitives/ScalarProperties.cs
@@ -12,7 +12,7 @@ public class ScalarPropertiesTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             ScalarPropertiesHost host = new();
-            host.WriteTestDataWithProperties(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/TypeSystem/Namespace/Host_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Namespace/Host_Variations.cs
@@ -9,7 +9,7 @@ namespace FJS.UnitTests.TypeSystem.Namespace
             var output1 = SerializerHelper.SerializeType(writer =>
             {
                 GlobalHost1 host = new();
-                host.WriteTestData(writer, data);
+                host.Write(writer, data);
             });
             var output2 = SerializerHelper.SerializeUsingSTJ(data);
             Assert.Equal(output1, output2);
@@ -21,8 +21,8 @@ namespace FJS.UnitTests.TypeSystem.Namespace
             TestData data = new();
             var output1 = SerializerHelper.SerializeType(writer =>
             {
-                NestedHost1 host = new();
-                host.WriteTestData(writer, data);
+                Nested.NestedHost1 host = new();
+                host.Write(writer, data);
             });
             var output2 = SerializerHelper.SerializeUsingSTJ(data);
             Assert.Equal(output1, output2);
@@ -39,7 +39,7 @@ namespace FJS.UnitTests.TypeSystem.Namespace
     {
         [GeneratedSerialier]
         [RootType(typeof(TestData))]
-        partial class NestedHost1
+        public partial class NestedHost1
         {
         }
     }

--- a/FJS.UnitTests/TypeSystem/Namespace/Type_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Namespace/Type_Variations.cs
@@ -9,7 +9,7 @@ namespace FJS.UnitTests.TypeSystem.Namespace
             var output1 = SerializerHelper.SerializeType(writer =>
             {
                 GlobalHost2 host = new();
-                host.WriteTestData1(writer, data);
+                host.Write(writer, data);
             });
             var output2 = SerializerHelper.SerializeUsingSTJ(data);
             Assert.Equal(output1, output2);
@@ -22,7 +22,7 @@ namespace FJS.UnitTests.TypeSystem.Namespace
             var output1 = SerializerHelper.SerializeType(writer =>
             {
                 GlobalHost2 host = new();
-                host.WriteTestData2(writer, data);
+                host.Write(writer, data);
             });
             var output2 = SerializerHelper.SerializeUsingSTJ(data);
             Assert.Equal(output1, output2);

--- a/FJS.UnitTests/TypeSystem/Nesting/Host_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Nesting/Host_Variations.cs
@@ -9,7 +9,7 @@ public class HostVariationTests
             var output1 = SerializerHelper.SerializeType(writer =>
             {
                 HostParent.NestedHost2 host = new();
-                host.WriteTestData(writer, data);
+                host.Write(writer, data);
             });
             var output2 = SerializerHelper.SerializeUsingSTJ(data);
             Assert.Equal(output1, output2);

--- a/FJS.UnitTests/TypeSystem/Nesting/Type_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Nesting/Type_Variations.cs
@@ -9,7 +9,7 @@ public class TypeVariationTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             NestedHost3 host = new();
-            host.WriteTestData(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);

--- a/FJS.UnitTests/TypeSystem/ObjectGraphs/ObjectGraphs.cs
+++ b/FJS.UnitTests/TypeSystem/ObjectGraphs/ObjectGraphs.cs
@@ -34,7 +34,7 @@ public class ObjectGraphTests
         Cycle2 data = new();
         var output1 = SerializerHelper.SerializeType(writer =>
         {
-            SerializerHost2 host = new();
+            SerializerHost10 host = new();
             host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
@@ -80,7 +80,7 @@ partial class SerializerHost1
 
 [GeneratedSerialier]
 [RootType(typeof(Cycle2))]
-partial class SerializerHost2
+partial class SerializerHost10
 {
 }
 

--- a/FJS.UnitTests/TypeSystem/ObjectGraphs/ObjectGraphs.cs
+++ b/FJS.UnitTests/TypeSystem/ObjectGraphs/ObjectGraphs.cs
@@ -9,7 +9,7 @@ public class ObjectGraphTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost1 host = new();
-            host.WriteSelfReference(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -22,7 +22,7 @@ public class ObjectGraphTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost1 host = new();
-            host.WriteCycle1(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -35,7 +35,7 @@ public class ObjectGraphTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost2 host = new();
-            host.WriteCycle2(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);
@@ -48,7 +48,7 @@ public class ObjectGraphTests
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             SerializerHost1 host = new();
-            host.WriteCycle2(writer, data);
+            host.Write(writer, data);
         });
         var output2 = SerializerHelper.SerializeUsingSTJ(data);
         Assert.Equal(output1, output2);


### PR DESCRIPTION
1. Renamed Write{Type name} to Write().
2. Added catch-all Write() method.
3. Fixed a build error.