### PR TITLE
Deduplicate same RootType applied to a host multiple times.

### DIFF
--- a/FJS.Generator/ModelBuilder.cs
+++ b/FJS.Generator/ModelBuilder.cs
@@ -26,7 +26,8 @@ namespace FJS.Generator
                                     Symbol: (INamedTypeSymbol)semanticModel.Compilation.GetSymbolsWithName(enabledType).FirstOrDefault());
                             })
                             .Where(sym => sym.Symbol != null)
-                            .Select(sym => GatherTypeData(sym.Symbol, sym.EnabledType, visited));
+                            .GroupBy(sym => sym.EnabledType)
+                            .Select(g => GatherTypeData(g.First().Symbol, g.First().EnabledType, visited));
 
             var host = new Host
             {


### PR DESCRIPTION
This should eventually generate a diagnostic about being ignored by the generator.