### PR TITLE
Fully qualify type names in Write() parameter to avoid any collisions.

### DIFF
--- a/FJS.Generator/CodeGenerator.cs
+++ b/FJS.Generator/CodeGenerator.cs
@@ -76,7 +76,7 @@ namespace FJS.Generator
                                  .AddParameterListParameters(
                                      [
                                         Parameter(Identifier("writer")).WithType(ParseTypeName("Utf8JsonWriter")),
-                                        Parameter(Identifier("obj")).WithType(ParseTypeName(t.Name)),
+                                        Parameter(Identifier("obj")).WithType(ParseTypeName(string.Join(".", t.Namespace, t.Name))),
                                      ]
                                  )
                                  .AddBodyStatements(AddStatements(t.Members, state));

--- a/FJS.Generator/Model/TypeData.cs
+++ b/FJS.Generator/Model/TypeData.cs
@@ -6,6 +6,8 @@ namespace FJS.Generator.Model
     {
         public string Name { get; set; }
 
+        public string Namespace { get; set; }
+
         public List<MemberData> Members { get; } = new();
     }
 }

--- a/FJS.UnitTests/TypeSystem/Namespace/Host_Variations.cs
+++ b/FJS.UnitTests/TypeSystem/Namespace/Host_Variations.cs
@@ -44,7 +44,7 @@ namespace FJS.UnitTests.TypeSystem.Namespace
         }
     }
 
-    class TestData
+    public class TestData
     {
         public int Prop1 { get; set; }
     }


### PR DESCRIPTION
Fixed a bug in namespace hierarchy order.