### PR TITLE
Fix the gaps in generating full type closure

### DIFF
--- a/FJS.Generator/Emit/Emitter.Collections.cs
+++ b/FJS.Generator/Emit/Emitter.Collections.cs
@@ -8,18 +8,22 @@ namespace FJS.Generator.Emit;
 
 static partial class Emitter
 {
-    static void WriteCollection(List<StatementSyntax> stmts, MemberData member)
+    static void WriteCollection(CodeGeneratorState state, List<StatementSyntax> stmts, MemberData member)
     {
         switch (member.CollectionType)
         {
             case CollectionType.Sequential:
-                WriteArray(stmts, member);
+                WriteArray(state, stmts, member);
                 break;
         }
     }
 
-    static void WriteArray(List<StatementSyntax> stmts, MemberData member)
+    static void WriteArray(CodeGeneratorState state, List<StatementSyntax> stmts, MemberData member)
     {
+        if (member.ElementWritingMethod == MemberType.ComplexObject)
+        {
+            state.TypesToGenerate.Add(member.ElementType);
+        }
         stmts.Add(
             ExpressionStatement(
                 InvocationExpression(

--- a/FJS.Generator/Emit/Emitter.Scalar.cs
+++ b/FJS.Generator/Emit/Emitter.Scalar.cs
@@ -40,7 +40,7 @@ static partial class Emitter
                         ])))));
     }
 
-    static StatementSyntax WriteNullableValue(string type, MemberData member)
+    static StatementSyntax WriteNullableValue(CodeGeneratorState state, string type, MemberData member)
     {
         List<StatementSyntax> stmts = default;
         switch (member.ElementWritingMethod)
@@ -58,6 +58,7 @@ static partial class Emitter
                                     IdentifierName("Value")));
                 return stmts[0];
             case MemberType.ComplexObject:
+                state.TypesToGenerate.Add(member.ElementType);
                 return
                     ExpressionStatement(
                         InvocationExpression(IdentifierName("Write"),
@@ -119,7 +120,7 @@ static partial class Emitter
         return EmptyStatement();
     }
 
-    static void WriteNullable(List<StatementSyntax> stmts, string type, MemberData member)
+    static void WriteNullable(CodeGeneratorState state, List<StatementSyntax> stmts, string type, MemberData member)
     {
         stmts.Add(
             IfStatement(
@@ -130,7 +131,7 @@ static partial class Emitter
                     IdentifierName("HasValue")),
                 Block(new StatementSyntax[]
                     {
-                        WriteNullableValue(type, member),
+                        WriteNullableValue(state, type, member),
                     }),
                 ElseClause(Block(new StatementSyntax[] { WriteNullValue(member), }))));
     }

--- a/FJS.Generator/Emit/Emitter.cs
+++ b/FJS.Generator/Emit/Emitter.cs
@@ -22,7 +22,7 @@ static partial class Emitter
         while (types is { Count: > 0 })
         {
             var type = types[types.Count - 1];
-            if (state.Processed.Add(type.Name))
+            if (state.Processed.Add(type.FullName))
             {
                 surrogateType = surrogateType.AddMembers(GenerateMethodForType(type, state));
             }
@@ -68,18 +68,18 @@ static partial class Emitter
                                             ])),
                                         null)));
 
-    static MethodDeclarationSyntax GenerateMethodForType(TypeData t, CodeGeneratorState state)
+    static MethodDeclarationSyntax GenerateMethodForType(TypeData type, CodeGeneratorState state)
     {
-        state.Processed.Add(t.Name);
+        state.Processed.Add(type.FullName);
         return MethodDeclaration(ParseTypeName("void"), "Write")
                              .AddModifiers(Token(PublicKeyword))
                              .AddParameterListParameters(
                                  [
                                     Parameter(Identifier("writer")).WithType(ParseTypeName("Utf8JsonWriter")),
-                                    Parameter(Identifier("obj")).WithType(ParseTypeName(string.Join(".", t.Namespace, t.Name))),
+                                    Parameter(Identifier("obj")).WithType(ParseTypeName(type.FullName)),
                                  ]
                              )
-                             .AddBodyStatements(AddStatements(t.Members, $"{t.Namespace}.{t.Name}", state));
+                             .AddBodyStatements(AddStatements(type.Members, type.FullName, state));
     }
 
     static StatementSyntax[] AddStatements(List<MemberData> members, string type, CodeGeneratorState state)

--- a/FJS.Generator/Emit/Emitter.cs
+++ b/FJS.Generator/Emit/Emitter.cs
@@ -29,7 +29,7 @@ static partial class Emitter
             types.Remove(type);
         }
 
-        surrogateType = surrogateType.AddMembers(AddCatchAllWriteMethod());
+//        surrogateType = surrogateType.AddMembers(AddCatchAllWriteMethod());
         MemberDeclarationSyntax member = surrogateType;
 
         if (!string.IsNullOrEmpty(host.Namespace))

--- a/FJS.Generator/Emit/Emitter.cs
+++ b/FJS.Generator/Emit/Emitter.cs
@@ -15,8 +15,7 @@ static partial class Emitter
         CodeGeneratorState state = new();
         var surrogateType = ClassDeclaration(host.Name)
             .AddModifiers(Token(PartialKeyword))
-            .AddMembers(AddMethods(host.Types, state))
-            .AddMembers(AddCatchAllWriteMethod());
+            .AddMembers(AddMethods(host.Types, state));
 
         var types = state.TypesToGenerate;
 
@@ -30,6 +29,7 @@ static partial class Emitter
             types.Remove(type);
         }
 
+        surrogateType = surrogateType.AddMembers(AddCatchAllWriteMethod());
         MemberDeclarationSyntax member = surrogateType;
 
         if (!string.IsNullOrEmpty(host.Namespace))

--- a/FJS.Generator/Emit/Emitter.cs
+++ b/FJS.Generator/Emit/Emitter.cs
@@ -29,7 +29,7 @@ static partial class Emitter
             types.Remove(type);
         }
 
-        //        surrogateType = surrogateType.AddMembers(AddCatchAllWriteMethod());
+        surrogateType = surrogateType.AddMembers(AddCatchAllWriteMethod());
         MemberDeclarationSyntax member = surrogateType;
 
         if (!string.IsNullOrEmpty(host.Namespace))

--- a/FJS.Generator/Emit/Emitter.cs
+++ b/FJS.Generator/Emit/Emitter.cs
@@ -29,7 +29,7 @@ static partial class Emitter
             types.Remove(type);
         }
 
-//        surrogateType = surrogateType.AddMembers(AddCatchAllWriteMethod());
+        //        surrogateType = surrogateType.AddMembers(AddCatchAllWriteMethod());
         MemberDeclarationSyntax member = surrogateType;
 
         if (!string.IsNullOrEmpty(host.Namespace))
@@ -101,13 +101,13 @@ static partial class Emitter
             switch (member.MemberType)
             {
                 case MemberType.Collection:
-                    WriteCollection(stmts, member);
+                    WriteCollection(state, stmts, member);
                     break;
                 case MemberType.ComplexObject:
                     WriteSubobject(state, stmts, member);
                     break;
                 case MemberType.Nullable:
-                    WriteNullable(stmts, type, member);
+                    WriteNullable(state, stmts, type, member);
                     break;
                 case MemberType.Primitive:
                     WritePrimitiveValue(

--- a/FJS.Generator/Model/CodeGeneratorState.cs
+++ b/FJS.Generator/Model/CodeGeneratorState.cs
@@ -5,5 +5,6 @@ namespace FJS.Generator.Model;
 class CodeGeneratorState
 {
     public List<TypeData> TypesToGenerate { get; } = new();
+
     public HashSet<string> Processed { get; } = new();
 }

--- a/FJS.Generator/Model/TypeData.cs
+++ b/FJS.Generator/Model/TypeData.cs
@@ -4,9 +4,11 @@ namespace FJS.Generator.Model;
 
 class TypeData
 {
+    public string Namespace { get; set; }
+
     public string Name { get; set; }
 
-    public string Namespace { get; set; }
+    public string FullName => $"{Namespace}.{Name}";
 
     public List<MemberData> Members { get; } = new();
 }

--- a/FJS.UnitTests/Primitives/NullableFields.cs
+++ b/FJS.UnitTests/Primitives/NullableFields.cs
@@ -7,7 +7,7 @@ public class NullableFieldsTests
     [Fact]
     public void Serialize()
     {
-        NullableFieldsHost data = new();
+        NullableFields data = new();
         var output1 = SerializerHelper.SerializeType(writer =>
         {
             NullableFieldsHost host = new();


### PR DESCRIPTION
- Fixed various issues hidden by catch-all Write().
- Catch-all Write() will always be the last method in a generated class.
- Added closure for arrays and nullable when element type was a complex object.
- Emitter will use fully qualified type names for tracking processed type.
- Model builder will correctly include parent type names in case of a root type being nested inside others.